### PR TITLE
enable automatically numbered figures, tables and code-blocks

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -42,6 +42,9 @@ extensions = [
     'sphinx.ext.todo', 
 ]
 
+# If true, figures, tables and code-blocks are automatically numbered if they have a caption.
+numfig = True
+
 # Add any paths that contain templates here, relative to this directory.
 templates_path = ['../templates']
 


### PR DESCRIPTION
This PR enables automatic numbering of figures, tables, and code-blocks if they have a caption. This makes reading easier and allows for referencing of those elements.

Example
```
.. code-block:: bash
    :caption: Output of the cli-validator tool
    :name: lst-validator

    cli-validator rpki-validator.realmv6.org 8282
    93.175.146.0 24 12654
```