### PR TITLE
Add doc about RIPE NCC RPKI Validator 3.1

### DIFF
--- a/source/index.rst
+++ b/source/index.rst
@@ -57,6 +57,7 @@ The main documentation is organised into the following sections:
    krill/index
    routinator/index
    rtrlib/index
+   rpkivalidator3/index
 
 .. Indices and tables
 .. ------------------

--- a/source/rpkivalidator3/index.rst
+++ b/source/rpkivalidator3/index.rst
@@ -4,11 +4,11 @@
 RIPE NCC RPKI Validator 3.1
 ===========================
 
-Full-featured RPKI relying party software, written by the `RIPE NCC <http://ripe.net/>`_ in Java.
+A fully-featured RPKI relying party software, written by the `RIPE NCC <http://ripe.net/>`_ in Java.
 This application allows operators to download and validate the global RPKI data set for use in their BGP decision making
 process and router configuration. 
 
-The project consists of two separately deployable units called :ref:`RPKI Validator <rpki-validator>` and :ref:`RPKI-RTR Server <rpki-rtr-server>`.
+The project consists of two separate deployable units called the :ref:`RPKI Validator <rpki-validator>` and :ref:`RPKI-RTR Server <rpki-rtr-server>`.
 
 .. toctree::
    :maxdepth: 2
@@ -24,7 +24,7 @@ RPKI Validator
 
 Set up to run as a daemon, and has the following features:
 
-- Supports all current RPKI objects: certificates, manifests, CRLs, ROAs, router certificates and ghostbuster records
+- Supports all current RPKI objects: certificates, manifests, CRLs, ROAs, router certificates, and ghostbuster records
 - Supports the RRDP delta protocol
 - Supports caching RPKI data in case a repository is unavailable
 - Uses an asynchronous strategy to retrieve (often delegated) repositories, so that unavailable repositories do not block validation
@@ -34,14 +34,10 @@ Set up to run as a daemon, and has the following features:
 
 .. _rpki-rtr-server:
 
-RPKI-RTR server
+RPKI-RTR Server
 ---------------
 
-A separate daemon, that allows routers to connect using the RPKI-RTR protocol. 
-It's set up as a separate instance because not everyone needs to run this, but more importantly, 
-if you do need to run this then a separate daemon allows one to run more than one instance for redundancy
-(it keeps state even when the validator is down).
-
+A separate daemon that implements RPKI to the Router protocol (RTR), allowing *validated prefix origin* data to be delivered to routers. The RPKI-RTR Server is set up as a separate deamon because not everyone needs to run it. Far more importantly, a separate daemon allows you to start multiple instances for redundancy.
 
 For more information, check the `release notes <https://github.com/RIPE-NCC/rpki-validator-3/blob/master/rpki-validator/Changelog.txt>`_. 
 You can also contribute to the project on `GitHub <https://github.com/RIPE-NCC/rpki-validator-3>`_.

--- a/source/rpkivalidator3/index.rst
+++ b/source/rpkivalidator3/index.rst
@@ -1,0 +1,64 @@
+.. _doc_rpkivalidator3:
+
+
+RIPE NCC RPKI Validator 3.1
+===========================
+
+Full-featured RPKI relying party software, written by the `RIPE NCC <http://ripe.net/>`_ in Java.
+This application allows operators to download and validate the global RPKI data set for use in their BGP decision making
+process and router configuration. 
+
+The project consists of two separately deployable units called :ref:`RPKI Validator <rpki-validator>` and :ref:`RPKI-RTR Server <rpki-rtr-server>`.
+
+.. toctree::
+   :maxdepth: 2
+   :name: toc-rpkivalidator3
+
+   installation
+
+
+.. _rpki-validator:
+
+RPKI Validator
+--------------
+
+Set up to run as a daemon, and has the following features:
+
+- Supports all current RPKI objects: certificates, manifests, CRLs, ROAs, router certificates and ghostbuster records
+- Supports the RRDP delta protocol
+- Supports caching RPKI data in case a repository is unavailable
+- Uses an asynchronous strategy to retrieve (often delegated) repositories, so that unavailable repositories do not block validation
+- Features an API
+- Has a full UI
+- Supports exceptions trough local filters and assertions
+
+.. _rpki-rtr-server:
+
+RPKI-RTR server
+---------------
+
+A separate daemon, that allows routers to connect using the RPKI-RTR protocol. 
+It's set up as a separate instance because not everyone needs to run this, but more importantly, 
+if you do need to run this then a separate daemon allows one to run more than one instance for redundancy
+(it keeps state even when the validator is down).
+
+
+For more information, check the `release notes <https://github.com/RIPE-NCC/rpki-validator-3/blob/master/rpki-validator/Changelog.txt>`_. 
+You can also contribute to the project on `GitHub <https://github.com/RIPE-NCC/rpki-validator-3>`_.
+
+.. _requirements:
+
+System Requirements
+-------------------
+
+You will need a UNIX-like system with OpenJDK 8 or higher and rsync. 
+You will also need at least 1.5GB available on your server (2GB in total if you also run the RPKI-RTR server). 
+One (virtual) CPU should be enough. 
+The repository objects are stored in a file-based database, rather than in memory, for which we recommend at least 10GB of available disk space.
+
+
+
+
+.. history
+.. authors
+.. license

--- a/source/rpkivalidator3/installation.rst
+++ b/source/rpkivalidator3/installation.rst
@@ -1,0 +1,205 @@
+.. _doc_rpkivalidator3_installation:
+
+Installation
+============
+
+RIPE NCC provides a total of four options for installations:
+
+- :ref:`CentOS (rpm) <rpm>` 
+- :ref:`Debian (deb) <deb>`
+- :ref:`Generic build (tgz) <tgz>`
+- :ref:`Docker image <docker>` 
+
+.. _rpm:
+
+CentOS
+------
+
+We've set up a repository with CentOS 7 RPMs for Prod builds. 
+You can add the repository to your system as follows:
+
+.. code-block:: bash
+
+   sudo yum-config-manager --add-repo https://ftp.ripe.net/tools/rpki/validator3/prod/centos7/ripencc-rpki-prod.repo
+
+
+You may have to install 'yum-utils' first:
+
+.. code-block:: bash
+
+    sudo yum install yum-utils
+
+
+Install RPKI Validator:
+
+.. code-block:: bash
+
+    sudo yum install rpki-validator
+
+
+Install RPKI-RTR server:
+
+.. code-block:: bash
+
+    sudo yum install rpki-rtr-server
+
+Then run and enable the services:
+
+.. code-block:: bash
+
+    sudo systemctl enable rpki-validator-3 
+    sudo systemctl start rpki-validator-3
+
+.. code-block:: bash
+
+    sudo systemctl enable rpki-rtr-server 
+    sudo systemctl start rpki-rtr-server
+
+
+You can monitor the logs:
+
+.. code-block:: bash
+
+    sudo journalctl -f -u rpki-validator-3 
+    sudo journalctl -f -u rpki-rtr-server
+
+
+RPKI Validator 3.1 will be running on: http://localhost:8080/
+
+RPKI-RTR Server will be running on: http://localhost:8081/
+
+You can also explore the API here: http://localhost:8080/swagger-ui.html
+
+
+.. _deb:
+
+Debian
+------
+
+The Debian packages for rpki-validator and rpki-rtr server can be found here: https://ftp.ripe.net/ripe/tools/rpki/validator3/prod/deb/
+
+Download the suitable package and proceed with the installation:
+
+
+Install RPKI Validator:
+
+.. code-block:: bash
+
+    sudo apt install ./rpki-validator-3-latest.deb
+
+
+Install RPKI-RTR server:
+
+.. code-block:: bash
+
+    sudo apt install ./rpki-rtr-server-latest.deb
+
+Then run and enable the services:
+
+.. code-block:: bash
+
+    sudo systemctl enable rpki-validator-3 
+    sudo systemctl start rpki-validator-3
+
+.. code-block:: bash
+
+    sudo systemctl enable rpki-rtr-server 
+    sudo systemctl start rpki-rtr-server
+
+
+You can monitor the logs:
+
+.. code-block:: bash
+
+    sudo journalctl -f -u rpki-validator-3 
+    sudo journalctl -f -u rpki-rtr-server
+
+
+RPKI Validator 3.1 will be running on: http://localhost:8080/
+
+RPKI-RTR Server will be running on: http://localhost:8081/
+
+You can also explore the API here: http://localhost:8080/swagger-ui.html
+
+
+.. _tgz:
+
+Generic build
+-------------
+
+You can find generic production builds here: https://ftp.ripe.net/tools/rpki/validator3/prod/generic/
+Download the suitable package and unpack it.
+
+To run validator generic build:
+
+.. code-block:: bash
+
+    ./rpki-validator-3.sh
+
+
+To run rtr generic build:
+
+.. code-block:: bash
+
+    ./rpki-rtr-server.sh
+
+
+RPKI Validator 3.1 will be running on: http://localhost:8080/
+
+RPKI-RTR Server will be running on: http://localhost:8081/
+
+You can also explore the API here: http://localhost:8080/swagger-ui.html
+
+
+.. _docker:
+
+Docker
+------
+
+To run the Centos/RPM based image with systemd:
+
+.. code-block:: bash
+
+    docker pull  ripencc/rpki-validator-3-docker:latest
+    docker run --privileged --name rpkival -p 8080:8080 -d ripencc/rpki-validator-3-docker:latest
+
+
+To run the generic alpine based image:
+
+.. code-block:: bash
+
+    docker pull  ripencc/rpki-validator-3-docker:alpine
+    docker run --name validator-3-alpine -p 8080:8080 -d ripencc/rpki-validator-3-docker:alpine
+
+
+RPKI Validator 3.1 will be running on: http://localhost:8080/
+
+More info here: https://hub.docker.com/r/ripencc/rpki-validator-3-docker
+
+
+
+.. _extra-tals:
+
+Extra TALs
+------------------
+By default the validator will have TAs installed for AFRINIC, APNIC, LACNIC, RIPE NCC, but not ARIN.
+
+You can add download the ARIN TAL here. 
+Any of the formats will work, but the "RIPE NCC RPKI Validator" one will ensure that the TA will have a friendly name "ARIN". 
+
+To upload it you can use the following script:
+
+.. code-block:: bash
+
+    ./upload-tal.sh arin-ripevalidator.tal http://localhost:8080/
+
+
+The script should be in the root folder if you unpacked the generic build, or in /usr/bin if you installed using RPM/Debian package. 
+
+Alternatively, you can put extra TAL files to the preconfigured-tals directory of the RPKI Validator installation. 
+This directory is scanned on the start and all the parseable TALs are picked up for validation. 
+For RPM/Debian package installation the directory is /var/lib/rpki-validator-3/preconfigured-tals/.
+
+
+
+

--- a/source/rpkivalidator3/installation.rst
+++ b/source/rpkivalidator3/installation.rst
@@ -15,7 +15,7 @@ RIPE NCC provides a total of four options for installations:
 CentOS
 ------
 
-We've set up a repository with CentOS 7 RPMs for Prod builds. 
+We have set up a repository with CentOS 7 RPMs for Prod builds. 
 You can add the repository to your system as follows:
 
 .. code-block:: bash
@@ -23,27 +23,27 @@ You can add the repository to your system as follows:
    sudo yum-config-manager --add-repo https://ftp.ripe.net/tools/rpki/validator3/prod/centos7/ripencc-rpki-prod.repo
 
 
-You may have to install 'yum-utils' first:
+You might have to install 'yum-utils' first:
 
 .. code-block:: bash
 
     sudo yum install yum-utils
 
 
-Install RPKI Validator:
+Install the RPKI Validator:
 
 .. code-block:: bash
 
     sudo yum install rpki-validator
 
 
-Install RPKI-RTR server:
+Install the RPKI-RTR Server:
 
 .. code-block:: bash
 
     sudo yum install rpki-rtr-server
 
-Then run and enable the services:
+Run and enable the services:
 
 .. code-block:: bash
 
@@ -56,7 +56,7 @@ Then run and enable the services:
     sudo systemctl start rpki-rtr-server
 
 
-You can monitor the logs:
+To monitor the logs:
 
 .. code-block:: bash
 
@@ -64,11 +64,11 @@ You can monitor the logs:
     sudo journalctl -f -u rpki-rtr-server
 
 
-RPKI Validator 3.1 will be running on: http://localhost:8080/
+The RPKI Validator 3.1 will be running on http://localhost:8080/
 
-RPKI-RTR Server will be running on: http://localhost:8081/
+The RPKI-RTR Server will be running on http://localhost:8081/
 
-You can also explore the API here: http://localhost:8080/swagger-ui.html
+You can also explore the API at http://localhost:8080/swagger-ui.html
 
 
 .. _deb:
@@ -76,25 +76,25 @@ You can also explore the API here: http://localhost:8080/swagger-ui.html
 Debian
 ------
 
-The Debian packages for rpki-validator and rpki-rtr server can be found here: https://ftp.ripe.net/ripe/tools/rpki/validator3/prod/deb/
+The Debian packages for the RPKI Validator and RPKI-RTR Server can be found at: https://ftp.ripe.net/ripe/tools/rpki/validator3/prod/deb/
 
 Download the suitable package and proceed with the installation:
 
 
-Install RPKI Validator:
+Install the RPKI Validator:
 
 .. code-block:: bash
 
     sudo apt install ./rpki-validator-3-latest.deb
 
 
-Install RPKI-RTR server:
+Install the RPKI-RTR Server:
 
 .. code-block:: bash
 
     sudo apt install ./rpki-rtr-server-latest.deb
 
-Then run and enable the services:
+Run and enable the services:
 
 .. code-block:: bash
 
@@ -107,7 +107,7 @@ Then run and enable the services:
     sudo systemctl start rpki-rtr-server
 
 
-You can monitor the logs:
+To monitor the logs:
 
 .. code-block:: bash
 
@@ -115,11 +115,11 @@ You can monitor the logs:
     sudo journalctl -f -u rpki-rtr-server
 
 
-RPKI Validator 3.1 will be running on: http://localhost:8080/
+The RPKI Validator 3.1 will be running on http://localhost:8080/
 
-RPKI-RTR Server will be running on: http://localhost:8081/
+The RPKI-RTR Server will be running on http://localhost:8081/
 
-You can also explore the API here: http://localhost:8080/swagger-ui.html
+You can also explore the API at http://localhost:8080/swagger-ui.html
 
 
 .. _tgz:
@@ -127,28 +127,28 @@ You can also explore the API here: http://localhost:8080/swagger-ui.html
 Generic build
 -------------
 
-You can find generic production builds here: https://ftp.ripe.net/tools/rpki/validator3/prod/generic/
+You can find generic production builds at: https://ftp.ripe.net/tools/rpki/validator3/prod/generic/
 Download the suitable package and unpack it.
 
-To run validator generic build:
+To run the RPKI Validator generic build:
 
 .. code-block:: bash
 
     ./rpki-validator-3.sh
 
 
-To run rtr generic build:
+To run the RPKI-RTR generic build:
 
 .. code-block:: bash
 
     ./rpki-rtr-server.sh
 
 
-RPKI Validator 3.1 will be running on: http://localhost:8080/
+The RPKI Validator 3.1 will be running on http://localhost:8080/
 
-RPKI-RTR Server will be running on: http://localhost:8081/
+The RPKI-RTR Server will be running on http://localhost:8081/
 
-You can also explore the API here: http://localhost:8080/swagger-ui.html
+You can also explore the API at http://localhost:8080/swagger-ui.html
 
 
 .. _docker:
@@ -172,9 +172,9 @@ To run the generic alpine based image:
     docker run --name validator-3-alpine -p 8080:8080 -d ripencc/rpki-validator-3-docker:alpine
 
 
-RPKI Validator 3.1 will be running on: http://localhost:8080/
+The RPKI Validator 3.1 will be running on: http://localhost:8080/
 
-More info here: https://hub.docker.com/r/ripencc/rpki-validator-3-docker
+More info can be found at https://hub.docker.com/r/ripencc/rpki-validator-3-docker
 
 
 
@@ -182,23 +182,26 @@ More info here: https://hub.docker.com/r/ripencc/rpki-validator-3-docker
 
 Extra TALs
 ------------------
-By default the validator will have TAs installed for AFRINIC, APNIC, LACNIC, RIPE NCC, but not ARIN.
 
-You can add download the ARIN TAL here. 
-Any of the formats will work, but the "RIPE NCC RPKI Validator" one will ensure that the TA will have a friendly name "ARIN". 
+By default, the Validator will have Trust Anchor Locators (TALs) installed for AFRINIC, APNIC, LACNIC, RIPE NCC, but not ARIN.
 
-To upload it you can use the following script:
+You can download the ARIN TAL at https://www.arin.net/resources/manage/rpki/tal/
+
+Any of the formats will work, but the "RIPE NCC RPKI Validator format" will ensure that the TAL will have a friendly name like "ARIN".
+
+
+You can use the following script to upload it:
 
 .. code-block:: bash
 
     ./upload-tal.sh arin-ripevalidator.tal http://localhost:8080/
 
 
-The script should be in the root folder if you unpacked the generic build, or in /usr/bin if you installed using RPM/Debian package. 
+The script should be in the root folder if you unpacked the generic build, or in */usr/bin* if you installed it using RPM/Debian package. 
 
 Alternatively, you can put extra TAL files to the preconfigured-tals directory of the RPKI Validator installation. 
 This directory is scanned on the start and all the parseable TALs are picked up for validation. 
-For RPM/Debian package installation the directory is /var/lib/rpki-validator-3/preconfigured-tals/.
+For the RPM/Debian package installation the directory is */var/lib/rpki-validator-3/preconfigured-tals/*.
 
 
 


### PR DESCRIPTION
Includes a page describing:
- RPKI Validator
- RPKI-RTR Server
- System Requirements

Plus another page for installation methods:
- CentOS 
- Debian 
- Generic build
- Docker

And a small comment about installing extra TALs

