### PR TITLE
Updated to use requirements.txt and Python 2

### DIFF
--- a/README.md
+++ b/README.md
@@ -44,13 +44,12 @@ Similarly, you can include attachments (like assets as support material for a tu
 
 ## Building with Sphinx
 
-To build the HTML website (or any other format supported by Sphinx, like PDF, EPUB or LaTeX), you need to install [Sphinx](http://sphinx-doc.org/) >= 1.3 as well as (for the HTML) the [readthedocs.org theme](https://github.com/snide/sphinx_rtd_theme). Only the Python 3 flavour was tested, though the Python 2 versions might work too.
+To build the HTML website (or any other format supported by Sphinx, like PDF, EPUB or LaTeX), you need to install [Sphinx](http://sphinx-doc.org/) >= 1.3 as well as (for the HTML) the [readthedocs.org theme](https://github.com/snide/sphinx_rtd_theme). Only the Python 2 flavour was tested, though the Python 3 versions might work too.
 
-Those tools are best installed using [pip](https://pip.pypa.io), Python's module installer. The Python 3 version might be provided (on Linux distros) as `pip3` or `python3-pip`. You can then run:
+Those tools are best installed using [pip](https://pip.pypa.io), Python's module installer like so:
 
 ```sh
-pip3 install sphinx
-pip3 install sphinx_rtd_theme
+pip install sphinx sphinx_rtd_theme -r requirements.txt
 ```
 
 You can then build the HTML documentation from the root folder of this repository with:
@@ -96,10 +95,10 @@ If you want your Sphinx installation scoped to the project, you can install it u
 Execute this from the root folder of this repository:
 
 ```sh
-virtualenv --system-site-packages env/
-. env/bin/activate
-pip3 install sphinx
-pip3 install sphinx_rtd_theme
+pip install virtualenv
+virtualenv env
+source env/bin/activate
+pip install sphinx sphinx_rtd_theme -r requirements.txt
 ```
 
 Then do `make html` like above.


### PR DESCRIPTION
As the ReadTheDocs build uses Python 2, and currently with Python 3  `sphinxcontrib/contribui.py` fails with `AttributeError: 'Sphinx' object has no attribute 'info'`.