### PR TITLE
Various Krill doc improvements triggered by NLnetlabs/krill#247.

### DIFF
--- a/source/conf.py
+++ b/source/conf.py
@@ -41,6 +41,7 @@ release = u''
 extensions = [
     'sphinx.ext.todo',
     'sphinx.ext.extlinks',
+    'sphinxcontrib.plantuml'
 ]
 
 # If true, figures, tables and code-blocks are automatically numbered if they have a caption.

--- a/source/krill/api.rst
+++ b/source/krill/api.rst
@@ -7,32 +7,39 @@ The Krill API is a primarily JSON based REST-like HTTPS API with `bearer token
 <https://swagger.io/docs/specification/authentication/bearer-authentication/>`_
 based authentication.
 
-Documentation
--------------
+Getting Help
+------------
 
-View the `human readable interactive version of the Krill v0.6.2 API
-specification
-<http://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/NLnetLabs/krill/v0.6.2/doc/openapi.yaml>`_,
-made possible by the wonderful `ReDoc <https://github.com/Redocly/redoc>`_ tool.
+- Consult the `Interactive API documentation <http://redocly.github.io/redoc/?url=https://raw.githubusercontent.com/NLnetLabs/krill/v0.6.2/doc/openapi.yaml>`_ (courtesy of `ReDoc <https://github.com/Redocly/redoc>`_)
+- Follow the API links in the :ref:`Krill CLI documentation<doc_krill_using_cli>`, e.g. API Call: :krill_api:`GET /v1/cas <list_cas>`
+- Check out the API hints built-in to the :ref:`Krill CLI<doc_krill_using_cli>`, e.g.
 
-Specification
--------------
+.. parsed-literal::
 
-The raw `OpenAPI 3.0.2 specification
-<https://github.com/OAI/OpenAPI-Specification/blob/master/versions/3.0.2.md>`_
-description of the API is available in the Krill source repository (`v0.6.2 link
-<https://github.com/NLnetLabs/krill/blob/v0.6.2/doc/openapi.yaml>`_).
+   $ :ref:`krillc list<cmd_krillc_list>` --api
+   GET:
+     https://<your.domain>/api/v1/cas
+   Headers:
+     Authorization: Bearer *****
+
 
 Generating Client Code
 ----------------------
 
-The `OpenAPI Generator <https://openapi-generator.tech/>`_ can generate client
-code for using the krill API with your favourite language. Below is an example
-of how to do this using Docker and Python 3.
+The `OpenAPI Generator <https://openapi-generator.tech/>`_ can generate Krill
+API client code in many languages from the `Krill v0.6.2 OpenAPI specification <https://github.com/NLnetLabs/krill/blob/v0.6.2/doc/openapi.yaml>`_.
 
-First create a simple test Krill client program. Save the following as
-:file:`/tmp/krill_test.py`, replacing `<YOUR XXX>` values with the correct
-access token and domain name for your Krill server.
+Sample Application
+------------------
+
+Below is an example of how to write a small Krill client application in Python 3
+using a Krill API client library produced by the OpenAPI Generator. To try out
+this sample you'll need Docker and Python 3.
+
+1. Save the following as :file:`/tmp/krill_test.py`, replacing `<YOUR XXX>`
+values with the correct access token and domain name for your Krill server. This
+example assumes that your Krill instance API endpoint is available on port 443
+using a valid TLS certificate.
 
 .. code-block:: python3
 
@@ -58,17 +65,20 @@ access token and domain name for your Krill server.
    # Query Krill for the list of configured CAs
    print(krill_ca_api.list_cas())
 
-Now generate the Krill client library:
+2. Run the following commands in a shell to generate a Krill client library:
 
 .. code-block:: bash
 
+   # prepare a working directory
    GENDIR=/tmp/gen
    VENVDIR=/tmp/venv
-
    mkdir -p $GENDIR
 
+   # fetch the Krill OpenAPI specification document
    wget -O $GENDIR/openapi.yaml https://raw.githubusercontent.com/NLnetLabs/krill/v0.6.2/doc/openapi.yaml
 
+   # use the OpenAPI Generator to generate a Krill client library from the krill
+   # OpenAPI specification
    docker run --rm -v $GENDIR:/local \
        openapitools/openapi-generator-cli generate \
        -i /local/openapi.yaml \
@@ -76,20 +86,21 @@ Now generate the Krill client library:
        -o /local/out \
        --additional-properties=packageName=krill_api
 
+   # install the generated library where your Python 3 can find it
    python3 -m venv $VENVDIR
    source $VENVDIR/bin/activate
    pip3 install wheel
    pip3 install $GENDIR/out/
 
-And then run the sample client program:
+3. Run the sample application:
 
 .. code-block:: bash
 
-   python3 /tmp/krill_test.py
+   $ python3 /tmp/krill_test.py
+   {'cas': [{'handle': 'ca'}]}
 
-To learn more about using your OpenAPI generated client library consult the
-:file:`README.md` file that is created in the generated client library
-directory, e.g. :file:`$GENDIR/out/README.md` in the example above.
+.. Tip:: To learn more about using the generated client library, consult the
+         documentation in `$GENDIR/out/README.md`.
 
 .. Warning::
 

--- a/source/krill/cli.rst
+++ b/source/krill/cli.rst
@@ -1,23 +1,15 @@
 .. _doc_krill_using_cli:
+.. highlight:: none
 
 Using the CLI
 =============
 
+Introduction
+------------
+
 Every function of Krill can be controlled from the command line interface (CLI).
 The Krill CLI is a wrapper around the :ref:`Krill API<doc_krill_using_api>`
 which is based on JSON over HTTPS.
-
-It's convenient to set up the following environment variables so that you can
-easily use the Krill CLI on the same machine where Krill is running:
-
-.. code-block:: bash
-
-  export KRILL_CLI_TOKEN="correct-horse-battery-staple"
-  export KRILL_CLI_SERVER="https://localhost:3000/"
-  export KRILL_CLI_MY_CA="Acme-Corp-Intl"
-
-For your CA name, you can use alphanumeric characters, dashes and underscores,
-i.e. ``a-zA-Z0-9_``.
 
 Note that you can use the CLI from another machine, but then you will need to
 set up a proxy server in front of Krill and make sure that it has a real TLS
@@ -26,89 +18,671 @@ certificate.
 To use the CLI you need to invoke :command:`krillc` followed by one or more
 subcommands, and some arguments. Help is built-in:
 
-.. code-block:: bash
+.. parsed-literal::
 
-   krillc help [subcommand..]
+   $ :ref:`krillc help<cmd_krillc_help>` [subcommand..]
 
-The following arguments are expected by most subcommands:
+   USAGE:
+       krillc <subcommand..> [FLAGS] [OPTIONS]
 
-.. code-block:: bash
+   FLAGS:
+           --api        Only show the API call and exit. Or set env: KRILL_CLI_API=1
+       -h, --help       Prints help information
+       -V, --version    Prints version information
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+       -f, --format <type>     Report format: none|json|text (default) |xml. Or set env: KRILL_CLI_FORMAT
+       -s, --server <URI>      The full URI to the krill server. Or set env: KRILL_CLI_SERVER
+       -t, --token <string>    The secret token for the krill server. Or set env: KRILL_CLI_TOKEN
 
-   krillc subcommand [subcommand..]
-          [-s, --server https://<yourhost:port>/ ] \
-          [-t, --token <token> ]
-          [-f, --format text|json|none]   (default text)
-          [-c, --ca <ca_name>]            (for ca specific subcommands)
+Setting Defaults
+""""""""""""""""
 
-You can set default values for these arguments in environment variables, to make
-it a bit easier to use the CLI:
+As noted in the OPTIONS help text above you can set default values via
+environment variables for the most common arguments that need to be supplied to
+``krillc`` subcommands. When setting environment variables note the following
+requirements:
 
-+---------------------+------------------------------------------------------+
-| Variable            | Argument                                             |
-+=====================+======================================================+
-| KRILL_CLI_SERVER    | -s, --server                                         |
-+---------------------+------------------------------------------------------+
-| KRILL_CLI_TOKEN     | -t, --token                                          |
-+---------------------+------------------------------------------------------+
-| KRILL_CLI_FORMAT    | -f, --format (defaults to text)                      |
-+---------------------+------------------------------------------------------+
-| KRILL_CLI_MY_CA     | -c, --ca                                             |
-+---------------------+------------------------------------------------------+
+  - ``KRILL_CLI_SERVER`` must be in the form ``https://<host:port>/``.
+  - ``KRILL_CLI_MY_CA`` must consist only of alphanumeric characters, dashes and
+    underscores, i.e. ``a-zA-Z0-9_``.
 
 For example:
 
 .. code-block:: bash
 
-  export KRILL_CLI_TOKEN="correct-horse-battery-staple"
-  export KRILL_CLI_MY_CA="Acme-Corp-Intl"
+   export KRILL_CLI_TOKEN="correct-horse-battery-staple"
+   export KRILL_CLI_MY_CA="Acme-Corp-Intl"
 
 If you do use the command line argument equivalents, you will override whatever
 value you set in the ENV. Krill will give you a friendly error message if you
 did not set the applicable ENV variable, and don't include the command line
 argument equivalent.
 
-Setting up Your Certificate Authority
--------------------------------------
+Diagnosing Problems
+"""""""""""""""""""
 
-After Krill is running and configured, you can set up the Certificate Authority.
-This involves the following steps:
+You can show the history of all the things that happened to your CA using the
+:ref:`krillc history<cmd_krillc_history>` command.
 
-- Create your CA
-- Retrieve your CA's 'child request'
-- Retrieve your CA's 'publisher request'
-- Upload the 'publisher request' to your publisher
-- Save the 'repository response'
-- Update the repository for your CA using the 'repository response'
-- Upload the 'child request' to your parent
-- Save the 'parent response'
-- Add the parent using the 'parent response'
+Reference
+---------
+
+The reference below documents the available ``krillc`` subcommands. Flags and
+options that are the same for most subcommands are omitted in this section in
+order to focus on the most important aspects of each subcommand.
+
+*Tip*: Click on a subcommand name to jump to the help for that subcommand.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc [SUBCOMMAND]
+   
+   SUBCOMMANDS:
+       :ref:`action<cmd_krillc_action>`        Show details for a specific CA action.
+       :ref:`add<cmd_krillc_add>`           Add a new CA.
+       :ref:`bulk<cmd_krillc_bulk>`          Manually trigger refresh/republish/resync for all cas
+       :ref:`children<cmd_krillc_children>`      Manage children for a CA in Krill.
+       :ref:`config<cmd_krillc_config>`        Creates a configuration file for krill and prints it to STDOUT.
+       :ref:`health<cmd_krillc_health>`        Perform an authenticated health check
+       :ref:`help<cmd_krillc_help>`          Prints this message or the help of the given subcommand(s)
+       :ref:`history<cmd_krillc_history>`       Show full history of a CA.
+       :ref:`info<cmd_krillc_info>`          Show server info
+       :ref:`issues<cmd_krillc_issues>`        Show issues for CAs.
+       :ref:`keyroll<cmd_krillc_keyroll>`       Perform a manual key-roll in Krill.
+       :ref:`list<cmd_krillc_list>`          List the current CAs.
+       :ref:`parents<cmd_krillc_parents>`       Manage parents for this CA.
+       :ref:`publishers<cmd_krillc_publishers>`    Manage publishers in Krill.
+       :ref:`repo<cmd_krillc_repo>`          Manage the repository for your CA.
+       :ref:`roas<cmd_krillc_roas>`          Manage ROAs for your CA.
+       :ref:`show<cmd_krillc_show>`          Show details of a CA.
+   
+.. _cmd_krillc_action:
+
+krillc action
+"""""""""""""
+
+Show details for a specific historic CA action.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc action [FLAGS] [OPTIONS] --key <action key string>
+
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+           --key <action key string>    The action key (as shown in the history).
+
+....
+
+.. _cmd_krillc_add:
+
+krillc add
+""""""""""
+
+API Call: :krill_api:`POST /v1/cas <add_ca>`
+
+Adds a new CA.
+
+When adding a CA you need to choose a handle, essentially just a name. The term
+"handle" comes from :RFC:`8183` and is used in the communication protocol
+between parent and child CAs, as well as CAs and publication servers.
+
+The handle you select is not published in the RPKI but used as identification to
+parent and child CAs you interact with. You should choose a handle that helps
+others recognise your organisation. Once set, the handle cannot be be changed
+as it would interfere with the communication between parent and child CAs, as
+well as the publication repository.
+
+When a CA has been added, it is registered to publish locally in the Krill
+instance where it exists, but other than that it has no configuration yet. In
+order to do anything useful with a CA you will first have to add at least one
+parent to it, followed by some Route Origin Authorisations and/or child CAs.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc add [FLAGS] [OPTIONS]
+
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+
+.. Information:: The CA name may consist of alphanumeric characters, dashes and
+                 underscores, i.e. ``a-zA-Z0-9_``.
+
+....
+
+.. _cmd_krillc_bulk:
+
+krillc bulk
+"""""""""""
+
+Manually trigger refresh/republish/resync for all CAs.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc bulk [SUBCOMMAND]
+   
+   SUBCOMMANDS:
+       help       Prints this message or the help of the given subcommand(s)
+       :ref:`publish<cmd_krillc_bulk_publish>`    Force that all CAs create new objects if needed (in which case they will also sync)
+       :ref:`refresh<cmd_krillc_bulk_refresh>`    Force that all CAs ask their parents for updated certificates
+       :ref:`sync<cmd_krillc_bulk_sync>`       Force that all CAs sync with their repo server
+
+.. _cmd_krillc_bulk_publish:
+
+krillc bulk publish
+^^^^^^^^^^^^^^^^^^^
+
+Force that all CAs create new objects if needed (in which case they will also sync).
+
+.. parsed-literal::
+
+   USAGE:
+       krillc bulk publish [FLAGS] [OPTIONS]
+
+.. _cmd_krillc_bulk_refresh:
+
+krillc bulk refresh
+^^^^^^^^^^^^^^^^^^^
+
+Force that all CAs ask their parents for updated certificates.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc bulk refresh [FLAGS] [OPTIONS]
+
+.. _cmd_krillc_bulk_sync:
+
+krillc bulk sync
+^^^^^^^^^^^^^^^^
+
+API Call: :krill_api:`POST /v1/bulk/cas/sync/repo <resync_all_cas>`
+
+Force that all CAs sync with their repo server.
+
+If your CAs have somehow become out of sync with their repository, then they
+will automatically re-sync whenever there is an update like a renewal of
+manifest and crl (every 8 hours), or whenever ROAs are changed. However, you
+can force that *all* Krill CAs re-sync with this command.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc bulk sync [FLAGS] [OPTIONS]
+
+....
+
+.. _cmd_krillc_children:
+
+krillc children
+"""""""""""""""
+
+Manage children for a CA in Krill.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc children [SUBCOMMAND]
+   
+   SUBCOMMANDS:
+       :ref:`add<cmd_krillc_children_add>`         Add a child to a CA.
+       help        Prints this message or the help of the given subcommand(s)
+       :ref:`info<cmd_krillc_children_info>`        Show info for a child (id and resources).
+       :ref:`remove<cmd_krillc_children_remove>`      Remove an existing child from a CA.
+       :ref:`response<cmd_krillc_children_response>`    Get the RFC8183 response for a child.
+       :ref:`update<cmd_krillc_children_update>`      Update an existing child of a CA.
+
+.. _cmd_krillc_children_add:
+
+krillc children add
+^^^^^^^^^^^^^^^^^^^
+
+Add a child to a CA.
+
+To add a child, you will need to:
+  1. Choose a unique local name (handle) that the parent will use for the child
+  2. Choose initial resources (asn, ipv4, ipv6)
+  3. (for a remote child) Have an :rfc:`8183` request
+
+.. parsed-literal::
+
+   USAGE:
+       krillc children add [SUBCOMMAND]
+   
+   SUBCOMMANDS:
+       :ref:`embedded<cmd_krillc_children_add_embedded>`    Add a child in *this* Krill server
+       help        Prints this message or the help of the given subcommand(s)
+       :ref:`remote<cmd_krillc_children_add_remote>`      Add a remote child, and return the parent response
+
+.. _cmd_krillc_children_add_embedded:
+
+krillc children add embedded
+............................
+
+.. parsed-literal::
+
+   USAGE:
+       krillc children add embedded [FLAGS] [OPTIONS] --child <name>
+   
+   OPTIONS:
+       -a, --asn <AS resources>       The delegated AS resources: e.g. AS1, AS3-4
+       -c, --ca <name>                The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+           --child <name>             The name of the child CA you wish to control.
+       -4, --ipv4 <IPv4 resources>    The delegated IPv4 resources: e.g. 192.168.0.0/16
+       -6, --ipv6 <IPv6 resources>    The delegated IPv6 resources: e.g. 2001:db8::/32
+
+.. _cmd_krillc_children_add_remote:
+
+krillc children add remote
+..........................
+
+API Call: See: :krill_api:`POST /v1/cas/{parent_ca_handle}/children <add_child_ca>`
+
+Add a remote child.
+
+The default response is the :rfc:`8183` parent response XML file. Or, if you set
+``--format json`` you will get the plain API response.
+
+If you need the response again, you can use the
+:ref:`krillc children response<cmd_krillc_children_response>` command.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc children add remote [FLAGS] [OPTIONS] --child <name> --rfc8183 <<XML file>>
+   
+   OPTIONS:
+       -a, --asn <AS resources>       The delegated AS resources: e.g. AS1, AS3-4
+       -c, --ca <name>                The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+           --child <name>             The name of the child CA you wish to control.
+       -4, --ipv4 <IPv4 resources>    The delegated IPv4 resources: e.g. 192.168.0.0/16
+       -6, --ipv6 <IPv6 resources>    The delegated IPv6 resources: e.g. 2001:db8::/32
+           --rfc8183 <<XML file>>     The RFC8183 Child Request XML file.
+
+.. _cmd_krillc_children_info:
+
+krillc children info
+^^^^^^^^^^^^^^^^^^^^
+
+Show info for a child (id and resources).
+
+.. parsed-literal::
+
+   USAGE:
+       krillc children info [FLAGS] [OPTIONS] --child <name>
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+           --child <name>      The name of the child CA you wish to control.
+
+.. _cmd_krillc_children_remove:
+
+krillc children remove
+^^^^^^^^^^^^^^^^^^^^^^
+
+Remove an existing child from a CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc children remove [FLAGS] [OPTIONS] --child <name>
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+           --child <name>      The name of the child CA you wish to control.
+
+.. _cmd_krillc_children_response:
+
+krillc children response
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+API Call: :krill_api:`GET /v1/cas/{parent_ca_handle}/children/{child_ca_handle}/contact <get_child_ca_parent_contact>`
+
+Get the RFC8183 response for a child.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc children response [FLAGS] [OPTIONS] --child <name>
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+           --child <name>      The name of the child CA you wish to control.
+
+.. _cmd_krillc_children_updatE:
+
+krillc children update
+^^^^^^^^^^^^^^^^^^^^^^
+
+Update an existing child of a CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc children update [FLAGS] [OPTIONS] --child <name>
+   
+   OPTIONS:
+       -a, --asn <AS resources>                  The delegated AS resources: e.g. AS1, AS3-4
+       -c, --ca <name>                           The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+           --child <name>                        The name of the child CA you wish to control.
+           --idcert <DER encoded certificate>    The child's updated ID certificate
+       -4, --ipv4 <IPv4 resources>               The delegated IPv4 resources: e.g. 192.168.0.0/16
+       -6, --ipv6 <IPv6 resources>               The delegated IPv6 resources: e.g. 2001:db8::/32
+
+....
+
+.. _cmd_krillc_config:
+
+krillc config
+"""""""""""""
+
+Creates a configuration file for krill and prints it to STDOUT.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc config [SUBCOMMAND]
+   
+   SUBCOMMANDS:
+       help      Prints this message or the help of the given subcommand(s)
+       :ref:`repo<cmd_krillc_config_repo>`      Use a self-hosted repository (not recommended)
+       :ref:`simple<cmd_krillc_config_simple>`    Use a 3rd party repository for publishing
+
+.. _cmd_krillc_config_simple:
+
+krillc config simple
+^^^^^^^^^^^^^^^^^^^^
+
+Creates a configuration file that configures Krill to be used with external
+repositories.
+
+.. parsed-literal::
+
+    USAGE:
+        krillc config simple [FLAGS] [OPTIONS]
+    
+    OPTIONS:
+        -d, --data <path>       Override the default path (./data/) for the data directory (must end with slash).
+        -l, --logfile <path>    Override the default path (./krill.log) for the log file.
+
+.. _cmd_krillc_config_repo:
+
+krillc config repo
+^^^^^^^^^^^^^^^^^^
+
+Creates a configuration file that enables a self-hosted repository within Krill
+that CAs can be configured to publish to instead of publishing to an external
+repository.
+
+.. Warning:: Running your own repository service is not recommended. For more
+             information about using the self-hosted repository see
+             :ref:`doc_krill_publication_server`.
+
+.. parsed-literal::
+
+    USAGE:
+        krillc config repo [FLAGS] [OPTIONS] --rrdp <uri> --rsync <uri>
+    
+    OPTIONS:
+        -d, --data <path>       Override the default path (./data/) for the data directory (must end with s
+        lash).
+        -l, --logfile <path>    Override the default path (./krill.log) for the log file.
+            --rrdp <uri>        Specify the base https URI for your RRDP (excluding notify.xml), must end with '/'
+            --rsync <uri>       Specify the base rsync URI for your repository. must end with '/'.
+
+....
+
+.. _cmd_krillc_health:
+
+krillc health
+"""""""""""""
+
+Perform an authenticated health check. Verifies that the specified Krill server
+can be connected to, is able to verify the specified token and is, at least thus
+far, healthy.
+
+Can be used in automation scripts by checking the exit code:
+
++-----------+------------------------------------------------------------------+
+| Exit Code | Meaning                                                          |
++===========+==================================================================+
+| 0         | the Krill server appears to be healthy.                          |
++-----------+------------------------------------------------------------------+
+| non-zero  | incorrect server URI, token, connection failure or server error. |
++-----------+------------------------------------------------------------------+
+
+....
+
+.. _cmd_krillc_help:
+
+krillc help
+"""""""""""
+
+Prints the version of ``krillc`` and the complete list of possible subcommands
+with a short explanatory text for each one.
+
+....
+
+.. _cmd_krillc_history:
+
+krillc history
+""""""""""""""
+
+Show full history of a CA. Using this command you can show the history of all
+the things that happened to your CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc history [FLAGS] [OPTIONS]
+   
+   FLAGS:
+           --full       Show history including publication.
+   
+   OPTIONS:
+           --after <<RFC 3339 DateTime>>     Show commands issued after date/time in RFC 3339 format, e.g. 2020-04-
+                                             09T19:37:02Z
+           --before <<RFC 3339 DateTime>>    Show commands issued after date/time in RFC 3339 format, e.g. 2020-04-
+                                             09T19:37:02Z
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+           --offset <<number>>               Number of results to skip
+           --rows <<number>>                 Number of rows (max 250)
+
+Example:
 
 .. code-block:: bash
 
-  # Add CA
-  krillc add
+   $ krillc history
+   time::command::key::success
+   2020-06-07T20:33:21Z::Update repo to server at: https://localhost:3000/rfc8181/ca ::command--1591562001--1--cmd-ca-repo-update::OK
+   2020-06-07T20:34:18Z::Add parent 'ripencc' as 'RFC 6492 Parent' ::command--1591562058--2--cmd-ca-parent-add::OK
+   2020-06-07T20:34:19Z::Update entitlements under parent 'ripencc': 0 => asn: 0 blocks, v4: 1 blocks, v6: 1 blocks  ::command--1591562059--3--cmd-ca-parent-entitlements::OK
+   2020-06-07T20:34:20Z::Update received cert in RC '0', with resources 'asn: 0 blocks, v4: 1 blocks, v6: 1 blocks' ::command--1591562060--4--cmd-ca-rcn-receive::OK
+   2020-06-07T20:36:28Z::Update ROAs add: 2 remove: '0' ::command--1591562188--5--cmd-ca-roas-updated::OK
 
-  # retrieve your CA's 'child request'
-  krillc parents request > child_request.xml
+....
 
-  # retrieve your CA's 'publisher request'
-  krillc repo request > publisher_request.xml
+.. _cmd_krillc_info:
 
-Next, upload the publisher request XML file to your publication server provider
-and save the repository response XML file.
+krillc info
+"""""""""""
+
+Show server info. Prints the version of the Krill *server* and the date and time
+that it was last started, e.g.:
+
+.. parsed-literal::
+
+   USAGE:
+       krillc info [FLAGS] [OPTIONS]
+
+Example:
 
 .. code-block:: bash
 
-  # update the repository for you CA using the 'repository response'
-  krillc repo update remote --rfc8183 repository_response.xml
+   $ krillc info
+   Version: 0.6.2
+   Started: 2020-05-16T10:21:36+00:00
 
-Next, upload the child request XML file to your parent CA (e.g. via their
-portal) and save the parent response XML file.
+....
 
-.. code-block:: bash
+.. _cmd_krillc_issues:
 
-  # add the parent using the 'parent response'
-  krillc parents add remote --parent myparent --rfc8183 ./parent-response.xml
+krillc issues
+"""""""""""""
+
+Show issues for CAs.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc issues [FLAGS] [OPTIONS]
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+
+....
+
+.. _cmd_krillc_keyroll:
+
+krillc keyroll
+""""""""""""""
+
+Perform a manual key-roll in Krill.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc keyroll [SUBCOMMAND]
+   
+   SUBCOMMANDS:
+       :ref:`activate<cmd_krillc_keyroll_activate>`    Finish roll for all keys held by this CA.
+       help        Prints this message or the help of the given subcommand(s)
+       :ref:`init<cmd_krillc_keyroll_init>`        Initialise roll for all keys held by this CA.
+
+.. _cmd_krillc_keyroll_activate:
+
+krillc keyroll activate
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Finish roll for all keys held by this CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc keyroll activate [FLAGS] [OPTIONS]
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+
+.. _cmd_krillc_keyroll_init:
+
+krillc keyroll init
+^^^^^^^^^^^^^^^^^^^
+
+Initialise roll for all keys held by this CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc keyroll init [FLAGS] [OPTIONS]
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+
+....
+
+.. _cmd_krillc_list:
+
+krillc list
+"""""""""""
+
+API Call: :krill_api:`GET /v1/cas <list_cas>`
+
+List the current CAs.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc list [FLAGS] [OPTIONS]
+
+....
+
+.. _cmd_krillc_parents:
+
+krillc parents
+""""""""""""""
+
+Manage parents for this CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc parents [SUBCOMMAND]
+   
+   SUBCOMMANDS:
+       :ref:`add<cmd_krillc_parents_add>`        Add a parent to this CA.
+       :ref:`contact<cmd_krillc_parents_contact>`    Show contact information for a parent of this CA.
+       help       Prints this message or the help of the given subcommand(s)
+       :ref:`remove<cmd_krillc_parents_remove>`     Remove an existing parent from this CA.
+       :ref:`request<cmd_krillc_parents_request>`    Show RFC8183 Publisher Request XML
+       :ref:`update<cmd_krillc_parents_update>`     Update an existing remote parent of this CA.
+
+.. _cmd_krillc_parents_add:
+
+krillc parents add
+^^^^^^^^^^^^^^^^^^
+
+Add a parent to this CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc parents add [SUBCOMMAND]
+   
+   SUBCOMMANDS:
+       :ref:`embedded<cmd_krillc_parents_add_embedded>`    Add a parent that you manage in *this* Krill server
+       help        Prints this message or the help of the given subcommand(s)
+       :ref:`remote<cmd_krillc_parents_add_remote>`      Add a remote parent
+
+.. _cmd_krillc_parents_add_embedded:
+
+krillc parents add embedded
+^^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Add a parent that you manage in *this* Krill server.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc parents add embedded [FLAGS] [OPTIONS] --parent <name>
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+       -p, --parent <name>     The local name by which your ca refers to this parent.
+
+.. _cmd_krillc_parents_add_remote:
+
+krillc parents add remote
+^^^^^^^^^^^^^^^^^^^^^^^^^
+
+API Call: :krill_api:`POST /v1/cas/ca/parents <add_ca_parent>`
+
+Add a remote parent.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc parents add remote [FLAGS] [OPTIONS] --parent <name> --rfc8183 <<XML file>>
+   
+   OPTIONS:
+       -c, --ca <name>               The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+       -p, --parent <name>           The local name by which your ca refers to this parent.
+           --rfc8183 <<XML file>>    The RFC8183 Parent Response XML
 
 Note that you can use any local name for ``--parent``. This is the name that
 Krill will show to you. Similarly, Krill will use your local CA name which you
@@ -117,56 +691,588 @@ includes the names (or handles as they are called in the RFC) by which it refers
 to itself, and your CA. Krill will make sure that it uses these names in the
 communication with the parent. There is no need for these names to be the same.
 
-Managing Route Origin Authorisations
-------------------------------------
+Note that whichever handle you choose, your CA will use the handles that the
+parent response included for itself *and* for your CA in its communication with
+this parent. I.e. you may want to inspect the response and use the same handle
+for the parent (parent_handle attribute), and do not be surprised or alarmed if
+the parent refers to your ca (child_handle attribute) by some seemingly random
+name. Some parents do this to ensure unicity.
+
+In case you have multiple parents you may want to refer to them by names that
+make sense in your context.
+
+.. _cmd_krillc_parents_contact:
+
+krillc parents contact
+^^^^^^^^^^^^^^^^^^^^^^
+
+Show contact information for a parent of this CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc parents contact [FLAGS] [OPTIONS] --parent <name>
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+       -p, --parent <name>     The local name by which your ca refers to this parent.
+
+.. _cmd_krillc_parents_remove:
+
+krillc parents remove
+^^^^^^^^^^^^^^^^^^^^^
+
+Remove an existing parent from this CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc parents remove [FLAGS] [OPTIONS] --parent <name>
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+       -p, --parent <name>     The local name by which your ca refers to this parent.
+
+.. _cmd_krillc_parents_request:
+
+krillc parents request
+^^^^^^^^^^^^^^^^^^^^^^
+
+API Call: :krill_api:`GET /v1/cas/{ca_handle}/child_request.json <get_ca_child_request>`
+
+Show :rfc:`8183` Publisher Request XML for the named CA. This XML is needed when
+registering the CA as a child of another CA, local or remote. For more
+information see :ref:`doc_krill_registering_with_a_parent`.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc parents request [FLAGS] [OPTIONS]
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+
+.. _cmd_krillc_parents_update:
+
+krillc parents update
+^^^^^^^^^^^^^^^^^^^^^
+
+Update an existing remote parent of this CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc parents update [FLAGS] [OPTIONS] --parent <name> --rfc8183 <<XML file>>
+   
+   OPTIONS:
+       -c, --ca <name>               The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+       -p, --parent <name>           The local name by which your ca refers to this parent.
+           --rfc8183 <<XML file>>    The RFC8183 Parent Response XML
+
+....
+
+.. _cmd_krillc_publishers:
+
+krillc publishers
+"""""""""""""""""
+
+Manage publishers in Krill.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc publishers [SUBCOMMAND]
+   
+   SUBCOMMANDS:
+       :ref:`add<cmd_krillc_publishers_add>`         Add a publisher.
+       help        Prints this message or the help of the given subcommand(s)
+       :ref:`list<cmd_krillc_publishers_list>`        List all publishers.
+       :ref:`remove<cmd_krillc_publishers_remove>`      Remove a publisher.
+       :ref:`response<cmd_krillc_publishers_response>`    Show RFC8183 Repository Response for a publisher.
+       :ref:`show<cmd_krillc_publishers_show>`        Show details for a publisher.
+       :ref:`stale<cmd_krillc_publishers_stale>`       List all publishers which have not published in a while.
+       :ref:`stats<cmd_krillc_publishers_stats>`       Show publication server stats.
+
+.. _cmd_krillc_publishers_add:
+
+krillc publishers add
+^^^^^^^^^^^^^^^^^^^^^
+
+Add a publisher. In order to add a publisher you have to get its :rfc:`8183`
+Publisher Request XML, and hand it over to the server.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc publishers add [FLAGS] [OPTIONS] --rfc8183 <file>
+   
+   OPTIONS:
+       -p, --publisher <handle>    Override the publisher handle in the XML.
+           --rfc8183 <file>        RFC8183 Publisher Request XML file containing a certificate (tag is ignored)
+
+.. _cmd_krillc_publishers_list:
+
+krillc publishers list
+^^^^^^^^^^^^^^^^^^^^^^
+
+List all publishers. Note that the list of publishers will include any embedded
+Krill CAs as well as any possible remote (RFC 8181 compliant) publishers.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc publishers list [FLAGS] [OPTIONS]
+
+.. _cmd_krillc_publishers_remove:
+
+krillc publishers remove
+^^^^^^^^^^^^^^^^^^^^^^^^
+
+Remove a publisher. If you do, then all of its content will be removed as well
+and the publisher will no longer be allowed to publish.
+
+.. Warning:: You can do this without the publisher’s knowledge, nor consent,
+             even for embedded Krill CAs. With great power comes great
+             responsibility. That said, you can always add a publisher again
+             (also embedded publishers), and once a publisher can connect to
+             your repository again, it should be able to figure out that it
+             needs to re-publish all its content (Krill CAs will always check
+             for this).
+
+.. parsed-literal::
+
+   USAGE:
+       krillc publishers remove [FLAGS] [OPTIONS] --publisher <handle>
+   
+   OPTIONS:
+       -p, --publisher <handle>    The handle (name) of the publisher.
+
+.. _cmd_krillc_publishers_response:
+
+krillc publishers response
+^^^^^^^^^^^^^^^^^^^^^^^^^^
+
+Show RFC8183 Repository Response for a publisher.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc publishers response [FLAGS] [OPTIONS] --publisher <handle>
+   
+   OPTIONS:
+       -p, --publisher <handle>    The handle (name) of the publisher.
+
+Example:
+
+.. code-blocK:: bash
+
+   $ krillc publishers response --publisher ca
+   <repository_response xmlns="http://www.hactrn.net/uris/rpki/rpki-setup/" version="1" publisher_handle="ca" service_uri="https://localhost:3000/rfc8181/ca" sia_base="rsync://localhost/repo/ca/" rrdp_notification_uri="https://localhost:3000/rrdp/notification.xml">
+     <repository_bpki_ta> repository server id certificate base64 </repository_bpki_ta>
+   </repository_response>
+
+.. _cmd_krillc_publishers_show:
+
+krillc publishers show
+^^^^^^^^^^^^^^^^^^^^^^
+
+Show details for a publisher, including the files that they published.
+
+The default text output just shows the handle of the publisher, the hash of its
+identity certificate key, and the rsync URI jail under which the publisher is
+allowed to publish objects.
+
+The JSON response includes a lot more information, including the files which
+were published and the full ID certificate used by the publisher. Note that even
+embedded Krill CAs will have such a certificate, even if they access the
+repository server locally.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc publishers show [FLAGS] [OPTIONS] --publisher <handle>
+   
+   OPTIONS:
+       -p, --publisher <handle>    The handle (name) of the publisher.
+
+.. _cmd_krillc_publishers_stale:
+
+krillc publishers stale
+^^^^^^^^^^^^^^^^^^^^^^^
+
+List all publishers which have not published in a while.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc publishers stale [FLAGS] [OPTIONS] --seconds <seconds>
+   
+   OPTIONS:
+           --seconds <seconds>    The number of seconds since last publication.
+
+.. _cmd_krillc_publishers_stats:
+
+krillc publishers stats
+^^^^^^^^^^^^^^^^^^^^^^^
+
+Show publication server stats.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc publishers stats [FLAGS] [OPTIONS]
+
+....
+
+.. _cmd_krillc_repo:
+
+krillc repo
+"""""""""""
+
+Manage the repository for your CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc repo [SUBCOMMAND]
+   
+   SUBCOMMANDS:
+       help       Prints this message or the help of the given subcommand(s)
+       :ref:`request<cmd_krillc_repo_request>`    Show RFC8183 Publisher Request.
+       :ref:`show<cmd_krillc_repo_show>`       Show current repo config.
+       :ref:`state<cmd_krillc_repo_state>`      Show current repo state.
+       :ref:`update<cmd_krillc_repo_update>`     Change which repository this CA uses.
+
+.. _cmd_krillc_repo_request:
+
+krillc repo request
+^^^^^^^^^^^^^^^^^^^
+
+Show the :rfc:`8183` Publisher Request XML for a CA. You will need to hand this
+over to your remote repository so that they can add your CA.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc repo request [FLAGS] [OPTIONS]
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+
+Example:
+
+.. code-block:: bash
+
+   $ krillc repo request
+   <publisher_request xmlns="http://www.hactrn.net/uris/rpki/rpki-setup/" version="1" publisher_handle="ca">
+     <publisher_bpki_ta>your CA ID cert DER in base64</publisher_bpki_ta>
+   </publisher_request>
+
+.. _cmd_krillc_repo_show:
+
+krillc repo show
+^^^^^^^^^^^^^^^^
+
+Show which repository server your CA is using, as well as what is has published
+at the location. Krill will issue an actual list query to the repository and
+give back the response, or an error in case of issues.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc repo show [FLAGS] [OPTIONS]
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+
+Example:
+
+.. code-block:: bash
+
+   $ krillc repo show
+   Repository Details:
+     type:        embedded
+     base_uri:    rsync://localhost/repo/ca/
+     rpki_notify: https://localhost:3000/rrdp/notification.xml
+   
+   Currently published:
+     c6e130761ccf212aea4038e95f6ffb3029afac3494ffe5fde6eb5062c2fa37bd rsync://localhost/repo/ca/0/281E18225EE6DCEB8E98C0A7FB596242BFE64B13.mft
+     557c1a3b7a324a03444c33fd010c1a17540ed482faccab3ffe5d0ec4b7963fc8 rsync://localhost/repo/ca/0/31302e302e3132382e302f32302d3234203d3e20313233.roa
+     444a962cb193b30dd1919b283ec934a50ec9ed562aa280a2bd3d7a174b6e1336 rsync://localhost/repo/ca/0/281E18225EE6DCEB8E98C0A7FB596242BFE64B13.crl
+     874048a2df6ff1e63a14e69de489e8a78880a341db1072bab7a54a3a5174057d rsync://localhost/repo/ca/0/31302e302e302e302f32302d3234203d3e20313233.roa
+
+.. _cmd_krillc_repo_state:
+
+krillc repo state
+^^^^^^^^^^^^^^^^^
+
+Show current repo state.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc repo state [FLAGS] [OPTIONS]
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+
+.. _cmd_krillc_repo_update:
+
+krillc repo update
+^^^^^^^^^^^^^^^^^^
+
+Change which repository this CA uses.
+
+You can change which repository server is used by your CA. If you have multiple
+CAs you will have to repeat this for each of them. Also, note that by default
+your CAs will assume that they use the embedded publication server. So, in order
+to use a remote server you will have to use this process to change over.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc repo update [SUBCOMMAND]
+   
+   SUBCOMMANDS:
+       :ref:`embedded<cmd_krillc_repo_update_embedded>`    Use the embedded server in krill
+       help        Prints this message or the help of the given subcommand(s)
+       :ref:`remote<cmd_krillc_repo_update_remote>`      Use a remote server (RECOMMENDED)
+
+Changing repositories is actually more complicated than one might think, but
+fortunately it's all automated. When you ask Krill to change, the following
+steps will be executed:
+
+- check that the new repository can be reached, and this ca is authorised
+- regenerate all objects using the URI jail given by the new repository
+- publish all objects in the new repository
+- request new certificates from (all) parent CA(s) including the new URI
+- once received, do a best effort to clean up the old repository
+
+In short, Krill performs a sanity check that the new repository can be used,
+and then tries to migrate there in a way that will not lead to invalidating
+any currently signed objects.
+
+To start a migration you can use the following.
+
+.. parsed-literal::
+
+  $ :ref:`krillc repo update remote<cmd_krillc_repo_update_remote>` --rfc8183 [file]
+
+If no file is specified the CLI will try to read the XML from STDIN.
+
+Note that if you were using an embedded repository, and you instruct your CA
+to connect to the embedded repository, but set up as a *remote*, then you will
+find that you have no more published objects - because.. Krill tries to clean
+up the old repository, and we assume that you would not try to use an embedded
+server over the :rfc:`8181` protocol.
+
+But, suppose that you did, you would now see this:
+
+.. parsed-literal::
+
+  $ :ref:`krillc repo show<cmd_krillc_repo_show>`
+  Repository Details:
+    type:        remote
+    service uri: https://localhost:3000/rfc8181/ca
+    base_uri:    rsync://localhost/repo/ca/
+    rpki_notify: https://localhost:3000/rrdp/notification.xml
+
+  Currently published:
+    <nothing>
+
+But no worries.. this can be fixed.
+
+First, you may want to migrate back to using the embedded repository without
+the :rfc:`8181` protocol overhead:
+
+.. parsed-literal::
+
+  $ :ref:`krillc repo update embedded<cmd_krillc_repo_update_embedded>`
+
+But this does not solve your problem just yet. Or well, it will re-publish
+everything under the new embedded repository, but then it will clean up the
+'old' repository which happens to be the same one in this corner case.
+
+The solution is 're-syncing' as described in :ref:`krillc bulk sync<cmd_krillc_bulk_sync>`.
+
+.. _cmd_krillc_repo_update_embedded:
+
+krillc repo update embedded
+...........................
+
+Use the embedded server in krill.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc repo update embedded [FLAGS] [OPTIONS]
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+
+.. _cmd_krillc_repo_update_remote:
+
+krillc repo update remote
+.........................
+
+Use a remote server (RECOMMENDED).
+
+.. parsed-literal::
+
+   USAGE:
+       krillc repo update remote [FLAGS] [OPTIONS]
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+           --rfc8183 <file>    File containing the RFC8183 XML. Defaults to reading from STDIN
+
+....
+
+.. _cmd_krillc_roas:
+
+krillc roas
+"""""""""""
+
+Manage ROAs for your CA.
 
 Krill lets users create Route Origin Authorisations (ROAs), the signed objects
 that state which Autonomous System (AS) is authorised to originate one of your
 prefixes, along with the maximum prefix length it may have.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc roas [SUBCOMMAND]
+
+   SUBCOMMANDS:
+       help      Prints this message or the help of the given subcommand(s)
+       :ref:`list<cmd_krillc_roas_list>`      Show current authorizations.
+       :ref:`update<cmd_krillc_roas_update>`    Update authorizations.
+
+.. _cmd_krillc_roas_list:
+
+krillc roas list
+^^^^^^^^^^^^^^^^
+
+Show current authorizations.
+
+.. parsed-literal::
+
+   USAGE:
+       krillc roas list [FLAGS] [OPTIONS]
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+
+Example:
+
+You can list ROAs in the following way:
+
+.. code-block:: bash
+
+   $ krillc roas list
+   192.0.2.0/24 => 64496
+   2001:db8::/32-48 => 64496
+
+.. _cmd_krillc_roas_update:
+
+krillc roas update
+^^^^^^^^^^^^^^^^^^
+
+API Call: :krill_api:`POST /v1/cas/ca/routes <update_route_authorizations>`
+
+Update authorizations.
 
 You can update ROAs through the command line by submitting a plain text file
 with the following format:
 
 .. code-block:: text
 
- # Some comment
-   # Indented comment
+   # Some comment
+     # Indented comment
 
-  A: 192.0.2.0/24 => 64496
-  A: 2001:db8::/32-48 => 64496   # Add prefix with max length
-  R: 198.51.100.0/24 => 64496    # Remove existing authorisation
+   A: 10.0.0.0/24 => 64496
+   A: 10.1.0.0/16-20 => 64496   # Add prefix with max length
+   R: 10.0.3.0/24 => 64496      # Remove existing authorization
 
-You can then add this to your CA:
+.. parsed-literal::
 
-.. code-block:: text
+   USAGE:
+       krillc roas update [FLAGS] [OPTIONS] --delta <<file>>
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+           --delta <<file>>    Provide a delta file using the following format:
+                               # Some comment
+                                 # Indented comment
+                               
+                               A: 192.168.0.0/16 => 64496 # inline comment
+                               A: 192.168.1.0/24 => 64496
+                               R: 192.168.3.0/24 => 64496
 
- $ krillc roas update --delta ./roas.txt
+Example:
 
-If you followed the steps above then you would get an error, because there is no
-authorisation for 198.51.100.0/24 => 64496. If you remove the line and submit
-again, then you should see no response, and no error.
+.. code-block:: bash
 
-You can list ROAs in the following way:
+   $ krillc roas update --delta ./roas.txt
 
-.. code-block:: text
+....
 
-  $ krillc roas list
-  192.0.2.0/24 => 64496
-  2001:db8::/32-48 => 64496
+.. _cmd_krillc_show:
 
-Displaying History
-------------------
+krillc show
+"""""""""""
 
-You can show the history of all the things that happened to your CA using the
-:command:`history` command.
+API Call: :krill_api:`GET /v1/cas/{ca_handle} <get_ca>`
 
-.. code-block:: text
+Show details of a CA.
 
-  $ krillc history
-  id: ca version: 0 details: Initialised with ID key hash: 69ee7ef4dae43cd1dcd9ee65b8a1c7fd0c2499c3
-  id: ca version: 1 details: added RFC6492 parent 'ripencc'
-  id: ca version: 2 details: added resource class with name '0'
-  id: ca version: 3 details: requested certificate for key (hash) 'D5EE85EF047010771547FE3ACFE4316503B8EC6F' under resource class '0'
-  id: ca version: 4 details: activating pending key 'D5EE85EF047010771547FE3ACFE4316503B8EC6F' under resource class '0'
-  id: ca version: 5 details: added route authorization: '192.0.2.0/24 => 64496'
-  id: ca version: 6 details: added route authorization: '2001:db8::/32 => 64496'
+.. parsed-literal::
+
+   USAGE:
+       krillc show [FLAGS] [OPTIONS]
+   
+   OPTIONS:
+       -c, --ca <name>         The name of the CA you wish to control. Or set env: KRILL_CLI_MY_CA
+
+Example:
+
+.. code-block:: bash
+
+   $ krillc show --ca ca
+   Name:     ca
+ 
+   Base uri: rsync://localhostrepo/ca/
+   RRDP uri: https://localhost:3000/rrdp/notification.xml
+ 
+   ID cert PEM:
+   -----BEGIN CERTIFICATE-----
+   MIIDPDCCAiSgAwIBAgIBATANBgkqhkiG9w0BAQsFADAzMTEwLwYDVQQDEyg2NTA1
+   RDA4RUI5MTk5NkJFNkFERDNGOEYyQzUzQTUxNTg4RTY4NDJCMCAXDTE5MTIwMzEy
+   ..
+   zKtG5esZ+g48ihf6jBgDyyONXEICowcjrxlY5fnjHhL0jsTmLuITgYuRoGIK2KzQ
+   +qLiXg2G+8s8u/1PW7PVYg==
+   -----END CERTIFICATE-----
+ 
+   Hash: 9f1376b2e1c8052c1b5d94467f8708935224c518effbe7a1c0e967578fb2215e
+ 
+   Total resources:
+       ASNs:
+       IPv4: 10.0.0.0/8
+       IPv6: 2001:db8::/32
+ 
+   Parents:
+   Handle: ripencc Kind: RFC 6492 Parent
+ 
+   Resource Class: 0
+   Parent: ripencc
+   State: active    Resources:
+       ASNs:
+       IPv4: 10.0.0.0/8
+       IPv6: 2001:db8::/32
+   Current objects:
+     553A7C2E751CA0B04B49CB72E30EB5684F861987.crl
+     553A7C2E751CA0B04B49CB72E30EB5684F861987.mft
+ 
+   Children:
+   <none>

--- a/source/krill/creating-a-certificate-authority.rst
+++ b/source/krill/creating-a-certificate-authority.rst
@@ -1,0 +1,48 @@
+.. _doc_krill_creating_a_certificate_authority:
+
+Creating a Certificate Authority
+================================
+
+For most users the first step with Krill will be to create a Certificate
+Authority. How you create the CA depends on how you prefer to use Krill.
+
+Scenarios
+---------
+
+- If using the :ref:`Krill UI<doc_krill_using_ui>`, you will be prompted on
+  first use to enter the "handle" to use to create a new CA.
+
+- If using the :ref:`Krill CLI<doc_krill_using_cli>` use the following command
+  to create a new CA:
+
+  .. parsed-literal::
+
+     $ :ref:`krillc add<cmd_krillc_add>` --ca <handle>
+
+  .. tip:: After creating your new CA, set the ``KRILL_CLI_MY_CA`` environment
+           variable to the name of your new CA to reduce typing when using
+           subsequent commands. See the
+           :ref:`CLI documentation<doc_krill_using_cli>` for more information.
+
+- If using the :ref:`Krill API<doc_krill_using_api>` you will need to use the
+  :krill_api:`POST /v1/cas <add_ca>` endpoint to create a CA.
+
+- If using :ref:`Krill Manager<doc_krill_manager>` you will be prompted during
+  :ref:`initial setup<doc_krill_manager_initial_setup>` to enter a handle which
+  will Krill Manager will use to create a CA for you.
+
+.. Information:: If you intend to run the Krill instance as a dedicated
+                 :ref:`self-hosted repository<doc_krill_publication_server>`
+                 you do not need to add a CA if using the CLI, but when using
+                 the UI or Krill Manager you will be forced to do so anyway.
+
+Next Steps
+----------
+
+Learn how to:
+  - :ref:`Register your CA with a parent<doc_krill_registering_with_a_parent>`.
+  - :ref:`Register your CA with a repository<doc_krill_remote_publishing>`.
+  - Manage Route Origin Authorisations (ROAs):
+
+    - With the :ref:`krillc roas<cmd_krillc_roas>` CLI command.
+    - With the :ref:`Krill UI<doc_krill_using_ui>`.

--- a/source/krill/docker.rst
+++ b/source/krill/docker.rst
@@ -67,14 +67,14 @@ Local
 Using a Bash alias with ``<SOME_TOKEN>`` you can easily interact with the
 locally running Krill daemon via its command-line interface (CLI):
 
-.. code-block:: bash
+.. parsed-literal::
 
-    $ alias krillc='docker exec \
-      -e KRILL_CLI_SERVER=https://127.0.0.1:3000/ \
-      -e KRILL_CLI_TOKEN=correct-horse-battery-staple \
+    $ alias krillc='docker exec \\
+      -e KRILL_CLI_SERVER=https://127.0.0.1:3000/ \\
+      -e KRILL_CLI_TOKEN=correct-horse-battery-staple \\
       nlnetlabs/krill:v0.6.2 krillc'
 
-    $ krillc list -f json
+    $ :ref:`krillc list<cmd_krillc_list>` -f json
     {
       "cas": []
     }
@@ -85,14 +85,14 @@ Remote
 The Docker image can also be used to run :command:`krillc` to manage remote
 Krill servers. Using a shell alias simplifies this considerably:
 
-.. code-block:: bash
+.. parsed-literal::
 
-    $ alias krillc='docker run --rm \
-      -e KRILL_CLI_SERVER=https://rpki.example.net/ \
-      -e KRILL_CLI_TOKEN=correct-horse-battery-staple \
+    $ alias krillc='docker run --rm \\
+      -e KRILL_CLI_SERVER=https://rpki.example.net/ \\
+      -e KRILL_CLI_TOKEN=correct-horse-battery-staple \\
       -v /tmp/ka:/tmp/ka nlnetlabs/krill:v0.6.2 krillc'
 
-   $ krillc list -f json
+   $ :ref:`krillc list<cmd_krillc_list>` -f json
    {
       "cas": []
    }
@@ -100,9 +100,9 @@ Krill servers. Using a shell alias simplifies this considerably:
 Note: The ``-v`` volume mount is optional, but without it you will not be able
 to pass files to :command:`krillc` which some subcommands require, e.g.
 
-.. code-block:: bash
+.. parsed-literal::
 
-   $ krillc roas update --ca my_ca --delta /tmp/delta.in
+   $ :ref:`krillc roas update<cmd_krillc_roas_update>` --ca my_ca --delta /tmp/delta.in
 
 Service and Certificate URIs
 ----------------------------

--- a/source/krill/getting-started.rst
+++ b/source/krill/getting-started.rst
@@ -23,9 +23,13 @@ Krill can generate a basic configuration file for you. We are going to specify
 the two required directives, a secret token and the path to the data directory,
 and then store it in this directory.
 
-.. code-block:: bash
+.. parsed-literal::
 
-  krillc config simple --token correct-horse-battery-staple --data ~/data/ > ~/data/krill.conf
+  :ref:`krillc config simple<cmd_krillc_config_simple>` --token correct-horse-battery-staple --data ~/data/ > ~/data/krill.conf
+
+.. Note:: If you wish to run a self-hosted RPKI repository with Krill you will
+          need to use a different ``krillc config`` command. See :ref:`doc_krill_publication_server`
+          for more details.
 
 You can find a full example configuration file with defaults in `the
 GitHub repository

--- a/source/krill/index.rst
+++ b/source/krill/index.rst
@@ -74,12 +74,14 @@ Marketplace <https://aws.amazon.com/marketplace/pp/B0886F8GNJ>`_ and the
    installation
    getting-started
    parent-interactions
-   publication-server
+   creating-a-certificate-authority
+   registering-with-a-parent
    remote-publishing
    ui
    cli
    api
    monitoring
+   publication-server
    testing
    docker
    Running with Krill Manager <krillmanager/index>

--- a/source/krill/krillmanager/logging.rst
+++ b/source/krill/krillmanager/logging.rst
@@ -145,7 +145,7 @@ configure fluentd according to your own design, streaming logs to any of the
 many 3rd party services that fluentd supports. Configuration elemnents should be
 placed inside a label stanza like so:
 
-.. code-block:: xml
+.. parsed-literal::
 
    <label @ready>
      <match **>
@@ -261,7 +261,7 @@ When streaming to an external service you can either do that:
 Below is an example configuration for sending rsync access logs to
 Elasticsearch:
 
-.. code-block:: xml
+.. parsed-literal::
 
    # elastic-search.conf
    <label @ready>
@@ -301,7 +301,7 @@ CDN provider logs, not the NGINX logs.
 To stream rsync access logs to Elasticsearch but also still upload all logs to
 an S3 compatible storage target, use a copy configuration like so:
 
-.. code-block:: xml
+.. parsed-literal::
 
    # copy.conf
    <label @ready>

--- a/source/krill/parent-interactions.rst
+++ b/source/krill/parent-interactions.rst
@@ -15,7 +15,7 @@ Your identity, permissions and entitlements are all managed by the registry and
 exposed via their respective member portals. The rest of the information is
 exchanged in two XML files. You  will need to provide a child request generated
 by Krill, and in return you will receive a parent response that you need to give
-back to Krill.
+back to Krill. See :ref:`doc_krill_remote_publishing` for more details.
 
 Hosted Publication Server
 -------------------------
@@ -35,6 +35,8 @@ their members, upon request. Most other RIRs have it on their roadmap. NIC.br,
 the Brazilian NIR, provides an RPKI repository server for their members as well.
 This means that in most cases you will have to publish your certificate and ROAs
 yourself, as described in the :ref:`doc_krill_publication_server` section.
+
+.. _member_portals:
 
 Member Portals
 --------------

--- a/source/krill/publication-server.rst
+++ b/source/krill/publication-server.rst
@@ -1,7 +1,7 @@
 .. _doc_krill_publication_server:
 
-Publication Server
-==================
+Running a Publication Server
+============================
 
 .. Important:: It is highly recommended to use an RPKI publication server
                provided by your parent CA, if available. This relieves you of
@@ -32,8 +32,8 @@ front of your web servers. Please note that the official name for the HTTPS
 based transport is the RPKI Repository Delta Protocol (RRDP), so you will see
 this abbreviation used throughout the documentation.
 
-Using the Embedded Repository
------------------------------
+Creating the Embedded Repository
+--------------------------------
 
 .. Warning:: Please note it is practically impossible to change the
              configuration of Krill's embedded repository after it has been
@@ -42,19 +42,33 @@ Using the Embedded Repository
              instance running as a repository only, as described in
              :ref:`doc_krill_remote_publishing`.
 
+.. Note:: The Krill UI is not currently aimed at using Krill as a repository
+          server. For example when visiting the UI of a Krill instance intended
+          for use only as a repository and not as a CA, it will still prompt you
+          on first use to create a CA. There is also no support via the UI for
+          managing the repository, for example it is not possible via the UI to
+          complete and child request to register with the repository.
+
 Krill can use an embedded repository to publish RPKI objects. It can generate
-the required configuration for you using the :command:`krillc config`
+the required configuration for you using the :ref:`krillc config<cmd_krillc_config>`
 subcommand. This ensures the syntax is correct, as for example trailing slashes
 are required. Use this command with your own values, using domain names pointing
 to servers that are publicly reachable.
 
-.. code-block:: bash
+.. parsed-literal::
 
-  krillc config repo \
-     --token correct-horse-battery-staple \
-     --data ~/data/ \
-     --rrdp "https://rpki.example.net/rrdp/" \
+  :ref:`krillc config repo<cmd_krillc_config_repo>` \\
+     --token correct-horse-battery-staple \\
+     --data ~/data/ \\
+     --rrdp "https://rpki.example.net/rrdp/" \\
      --rsync "rsync://rpki.example.net/repo/" > krill.conf
+
+Configuring Repository Servers
+------------------------------
+
+Krill runs the publication server. To actually serve the published content to
+Rsync and RRDP clients you will need to run your own *repository* servers using
+tools such as Rsyncd and NGINX.
 
 Krill will write the repository files under its data directory:
 
@@ -75,6 +89,9 @@ entire repository to a new folder under :file:`$DATA_DIR/repo/rsync` and then
 renames it. This is done to minimise issues with files being updated while
 relying party software is fetching data.
 
+Rsync
+"""""
+
 The next step is to configure your rsync daemons to expose a 'module' for your
 files. Make sure that the Rsync URI including the 'module' matches the
 :file:`rsync_base` in your Krill configuration file. Basic configuration can
@@ -93,6 +110,9 @@ then be as simple as:
   comment = RPKI repository
   read only = yes
 
+RRDP
+""""
+
 For RRDP you will need to set up a web server of your choice and ensure that it
 has a valid TLS certificate. Next, you can make the files found under, or copied
 from :file:`$DATA_DIR/repo/rrdp` available here. Make sure that the public URI
@@ -104,6 +124,14 @@ your load and uptime requirements. If you do, make sure that the public URI
 matches the directive in :file:`krill.conf`, because this will be used in your
 RPKI certificate.
 
+Publishing in the Repository
+----------------------------
+
+See :ref:`remote_publishing_to_krill_repo` in :ref:`doc_krill_remote_publishing`.
+
+Migrating the Repository
+------------------------
+
 If you find that there is an issue with your repository or, for example, you
 want to change its domain name, you can set up a new Krill instance with an
 embedded repository. When you are satisfied that the new one is correct, you
@@ -114,3 +142,4 @@ Krill will then make sure that objects are moved properly, and that a new
 certificate is requested from your parent(s) to match the new location. This
 scenario would also apply when your RIR starts providing a repository service.
 You can update your CA to start publishing there instead.
+

--- a/source/krill/registering-with-a-parent.rst
+++ b/source/krill/registering-with-a-parent.rst
@@ -8,7 +8,12 @@ you will need to register your CA with a parent in the hierarchy. Typically that
 will be an RIR or NIR, but as mentioned in the :ref:`introduction<doc_krill>` it
 could also be a parent within your business.
 
-To register with an RPKI parent you need to exchange :rfc:`8183` XML files
+Krill supports two communication modes:
+
+1. embedded, meaning the both the parent and child CA live in the same Krill
+2. remote, meaning that the official RFC protocol is used
+
+To register with an RPKI remote parent you need to exchange :rfc:`8183` XML files
 with the parent via their :ref:`web portal<member_portals>` or API.
 
 .. uml::
@@ -39,8 +44,8 @@ Scenarios
 Krill CA -> NIR/RIR Remote CA
 """""""""""""""""""""""""""""
 
-Registering a Krill CA as a child with a remote Krill CA may require that you
-log in to and interact with the a parent web portal, e.g.:
+.. Note:: Registering a Krill CA as a child with a remote Krill CA may require
+          that you log in to and interact with the a parent web portal.
 
 #. In the Krill UI copy/download the :rfc:`8183` Child Request.
 
@@ -66,14 +71,14 @@ following commands:
 .. parsed-literal::
 
    Communicating with the CA server Krill instance:
-   1. :ref:`krillc parents request<cmd_parents_request>`        Show RFC8183 Child Request XML.
+   1. :ref:`krillc parents request<cmd_krillc_parents_request>`        Show RFC8183 Child Request XML.
 
    Communicating with the remote Krill CA instance:
-   2. :ref:`krillc children add remote<cmd_children_add_remote>`    Add a child to a CA..
-   3. :ref:`krillc children response<cmd_children_response>`      Show RFC8183 Parent Response XML.
+   2. :ref:`krillc children add remote<cmd_krillc_children_add_remote>`    Add a child to a CA..
+   3. :ref:`krillc children response<cmd_krillc_children_response>`      Show RFC8183 Parent Response XML.
 
    Communicating with the CA server Krill instance:
-   4. :ref:`krillc parents add remote<cmd_parents_add_remote>`     Add a parent to this CA.
+   4. :ref:`krillc parents add remote<cmd_krillc_parents_add_remote>`     Add a parent to this CA.
 
 
 Krill CA -> Krill Local CA
@@ -85,4 +90,4 @@ with the following commands:
 .. parsed-literal::
 
    Communicating with the CA server Krill instance:
-   1. :ref:`krillc parents add embedded<cmd_parents_add_embedded>`
+   1. :ref:`krillc parents add embedded<cmd_krillc_parents_add_embedded>`

--- a/source/krill/ui.rst
+++ b/source/krill/ui.rst
@@ -47,6 +47,8 @@ recognise your organisation. Once set, the handle cannot be changed.
 
     Enter a handle for your Certificate Authority
 
+.. _doc_krill_using_ui_repository_setup:
+
 Repository Setup
 ----------------
 

--- a/source/tools.rst
+++ b/source/tools.rst
@@ -13,6 +13,8 @@ supporting tools that help deployment and integration.
 .. index:: Relying Party software
   see: RPKI Validator; Relying Party software
 
+.. _relying_party_software:
+
 Relying Party Software
 ----------------------
 


### PR DESCRIPTION
Primary changes:
  - Attempt to make a clear path through the docs.
  - Attempt to reduce/avoid duplicate content.
  - Move all CLI documentation to a single place and make CLI commands clickable.
  - Tweaks to the testing with Krill page, including how to use Routinator with the TA.
  - Uses the Sphinx plantuml support to add a couple of diagrams.

Other changes:
  - Tweaks to the using the API page.